### PR TITLE
Fix update script working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,17 @@ Drag and drop your audio file (and optionally transcript and lexicon files) then
 
 ## Updating
 
-To get the latest version of AudioGUI, run:
+To get the latest version of AudioGUI, use the update script.
+
+On Windows run:
 
 ```bash
 update.bat
+```
+
+On other platforms use:
+
+```bash
+python update.py
 ```
 

--- a/update.bat
+++ b/update.bat
@@ -1,19 +1,16 @@
 @echo off
 REM Automatically update repository from GitHub
 
-REM Check if git is available
+REM Ensure current directory is the script's location
+cd /d %~dp0
+
+REM Prefer git if available
 where git >nul 2>&1
-IF ERRORLEVEL 1 (
-    echo git is not installed or not found in PATH.
-    exit /b 1
+if %errorlevel%==0 (
+    echo 🔄 Updating repository via git...
+    git pull
+    goto :eof
 )
 
-REM Pull latest changes
-echo 🔄 Updating repository...
-git pull
-IF ERRORLEVEL 1 (
-    echo Failed to update from GitHub.
-    exit /b 1
-)
-
-echo Update complete.
+REM Fallback to Python download
+python update.py

--- a/update.py
+++ b/update.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+
+REPO_ZIP_URL = "https://github.com/dpsjksjx900/AudioGUI/archive/refs/heads/main.zip"
+
+
+def update_from_zip(repo_dir: str) -> None:
+    """Download the latest repo zip and replace files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zip_path = os.path.join(tmpdir, "repo.zip")
+        print("\U0001F4E6  Downloading latest version...")
+        urllib.request.urlretrieve(REPO_ZIP_URL, zip_path)
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            zf.extractall(tmpdir)
+        extracted_root = os.path.join(tmpdir, "AudioGUI-main")
+        for name in os.listdir(extracted_root):
+            if name in {"venv", ".git"}:
+                continue
+            src = os.path.join(extracted_root, name)
+            dst = os.path.join(repo_dir, name)
+            if os.path.isdir(src):
+                if os.path.exists(dst):
+                    shutil.rmtree(dst)
+                shutil.copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+    print("\u2705  Update complete.")
+
+
+if __name__ == "__main__":
+    repo_dir = os.path.dirname(os.path.abspath(__file__))
+    update_from_zip(repo_dir)


### PR DESCRIPTION
## Summary
- ensure update.bat runs from repo directory
- fallback to update.py when git is missing
- implement update.py to download latest repo zip
- document cross-platform updating instructions

## Testing
- `python -m py_compile update.py`


------
https://chatgpt.com/codex/tasks/task_e_68595a8c587c8333a4b4dbd51b087ff5